### PR TITLE
Bump netty to 4.1.137.Final to clear CVE-2025-59419 in the Flink job-server jar

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -631,7 +631,8 @@ class BeamModulePlugin implements Plugin<Project> {
     def log4j2_version = "2.25.3"
     def nemo_version = "0.1"
     // [bomupgrader] determined by: io.grpc:grpc-netty, consistent with: google_cloud_platform_libraries_bom
-    def netty_version = "4.1.124.Final"
+    // Held above the bomupgrader's choice: netty-all below 4.1.129.Final carries CVE-2025-59419.
+    def netty_version = "4.1.137.Final"
     // [bomupgrader] determined by: io.opentelemetry:opentelemetry-sdk, consistent with: google_cloud_platform_libraries_bom
     def opentelemetry_version = "1.51.0"
     def postgres_version = "42.6.2"


### PR DESCRIPTION
- `BeamModulePlugin.groovy:853` declares `io.netty:netty-all`, the aggregate that drags in `netty-codec-smtp`; at `4.1.124.Final` that's [CVE-2025-59419](https://github.com/advisories/GHSA-jq43-27x9-3v86) (CRLF injection in `DefaultSmtpRequest`), a HIGH finding on Glean's `flink-invoker` image across 44 tags. Tracked as [EN-1741466](https://askscio.atlassian.net/browse/EN-1741466).
- Bumps `netty_version` to `4.1.137.Final` — latest 4.1.x, past the `4.1.129.Final` fix, matches the `netty-all` pin in scio's `MODULE.bazel`. Upstream Beam master is on `4.1.133.Final`, so this isn't ahead of what Beam tests against.
- The `[bomupgrader]` marker means a future BOM sync would silently regress this, so the line carries a comment saying it's deliberately held high.
- Verified on a rebuild of `:runners:flink:2.0:job-server:shadowJar`: all 31 `io.netty` artifacts move to `4.1.137.Final`; the fix is visible in bytecode (`SmtpUtils.class` 835 → 2433 bytes, `DefaultSmtpRequest.class` 3000 → 3114); the entry-list diff vs. the deployed jar is entirely under `io/netty/` (19 removed, 45 added); the jar boots and runs a real pipeline end to end.
- Scio side: [askscio/scio#282562](https://github.com/askscio/scio/pull/282562), pointing at `beam-runners-flink-2.0-job-server-2.73.0-netty-4.1.137.jar` (sha256 `07807c77cd9981af4a304fbadcf358b42405764ace3e076fc792cd3cb44c03dd`).
- Caveat: Flink's shaded copy (`org/apache/flink/shaded/netty4/…/smtp/`) comes from `flink-shaded-netty` and is untouched — no Maven coordinates so scanners don't flag it, and equally unreachable. The codec was never callable anyway (0 references across 158,648 classes), so this stops shipping vulnerable bytes rather than closing a live hole.
